### PR TITLE
Adds persistence to user locale preference (#87)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Carpe"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "built",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod networks;
 mod query;
 mod examples;
 mod app_version;
+mod preferences;
 
 pub use wallets::*;
 pub use swarm::*;
@@ -17,3 +18,4 @@ pub use networks::*;
 pub use query::*;
 pub use examples::*;
 pub use app_version::*;
+pub use preferences::*;

--- a/src-tauri/src/commands/preferences.rs
+++ b/src-tauri/src/commands/preferences.rs
@@ -1,0 +1,60 @@
+use std::{path::PathBuf};
+use std::fs::File;
+use crate::carpe_error::CarpeError;
+use anyhow::Error;
+use std::io::prelude::*;
+
+const PREFERENCES_DB_FILE: &str = "preferences.json";
+
+#[derive(serde::Deserialize, serde::Serialize, Debug)]
+pub struct Preferences {
+  pub locale: Option<String>
+}
+
+/*
+  get preferences
+*/
+#[tauri::command]
+pub fn get_preferences() -> Result<Preferences, CarpeError> {
+  let preferences = read_preferences()?;
+  Ok(preferences)
+}
+
+/*
+  set preferences
+*/
+#[tauri::command(async)]
+pub fn set_preferences_locale(locale: String) -> Result<(), CarpeError> {
+  let mut preferences = read_preferences()?;
+  preferences.locale = Some(locale);
+  update_preferences(&preferences)
+}
+
+fn read_preferences() -> Result<Preferences, Error> {
+  let db_path = preferences_db_path();
+  match db_path.exists() {
+    true => {
+      let file = File::open(db_path)?;
+      Ok(serde_json::from_reader(file)?)
+    },
+    false => {
+      Ok(Preferences { locale: None })
+    }    
+  }   
+}
+
+fn preferences_db_path() -> PathBuf {
+  dirs::home_dir().unwrap().join(".0L").join(PREFERENCES_DB_FILE)
+}
+
+fn update_preferences(preferences: &Preferences) -> Result<(), CarpeError> {
+  let db_path = preferences_db_path();
+  let serialized = serde_json::to_vec(preferences)
+    .map_err(|e| CarpeError::config(&format!("json preferences db should serialize, {:?}", &e)))?;
+
+  File::create(db_path)
+    .map_err(|e| CarpeError::config(&format!("carpe preferences_db_file should be created!, {:?}", &e)))?  
+    .write_all(&serialized)  
+    .map_err(|e| CarpeError::config(&format!("carpe preferences_db_file should be written!, {:?}", &e)))?;
+  Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -105,6 +105,9 @@ fn main() {
       mock_build_tower,
       start_forever_task,
       debug_start_listener,
+      // Preferences
+      get_preferences,
+      set_preferences_locale
     ])
     .menu(menu)
     .run(tauri::generate_context!())

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,11 +24,10 @@
   import { isCarpeInit} from "./accountActions";
   import { getVersion } from "./version";
   import { carpeTick } from "./tick";
-  import { getLocaleFromNavigator, setupI18n } from "./lang/i18n";
+  import { init_preferences } from "./preferences";
+  
+  init_preferences();
  
-  // ...
-  setupI18n({ withLocale: getLocaleFromNavigator() });
-
   let unlistenProofStart;
   let unlistenAck;
   let unlistenBacklogSuccess;

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
+
 export interface AccountEntry {
   account: string,
   authkey: string,

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -4,9 +4,10 @@
   import { signingAccount, isInit } from "../accounts";
   import AccountSwitcher from "./wallet/AccountSwitcher.svelte";
   import { routes } from "../routes";
-  import { setupI18n, _, getLocaleFromNavigator} from "../lang/i18n";
-
-  setupI18n({ withLocale: getLocaleFromNavigator() });
+  import { _ } from "../lang/i18n";
+  import { init_preferences } from "../preferences";
+  
+  init_preferences();
 
   const secondaryRoutes = [
     routes.settings,

--- a/src/components/settings/LangAppearanceSettings.svelte
+++ b/src/components/settings/LangAppearanceSettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { setupI18n, locale, _} from "../../lang/i18n";
+  import { _ } from "../../lang/i18n";
+  import { setLocale } from "../../preferences";
 
 </script>
 
@@ -13,14 +14,14 @@
       <button class="uk-button uk-button-default" type="button">{$_("settings.langapp_settings.lang_button")}</button>
       <div uk-dropdown="mode: click">
         <ul class="uk-nav uk-dropdown-nav">
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "en" }) }}>English</a></li>
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "zh_cn" }) }}>中文</a></li>
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "fr" }) }}>French</a></li>
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "de" }) }}>German</a></li>
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "es" }) }}>Spanish</a></li>
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "it" }) }}>Italian</a></li>
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "pt" }) }}>Portuguese</a></li>
-          <li><a class="uk-text-muted" href={"#"} on:click={() => { setupI18n({ withLocale: "ar" }) }}>Arabic</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("en")}>English</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("zh_cn")}>中文</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("fr")}>French</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("de")}>German</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("es")}>Spanish</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("it")}>Italian</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("pt")}>Portuguese</a></li>
+          <li><a class="uk-text-muted" href={"#"} on:click={() => setLocale("ar")}>Arabic</a></li>
         </ul>
       </div>
 

--- a/src/components/wallet/Newbie.svelte
+++ b/src/components/wallet/Newbie.svelte
@@ -1,9 +1,10 @@
 <script  lang="ts">
   import { Link } from "svelte-navigator";
   import { routes } from "../../routes";
-
-  import { getLocaleFromNavigator, setupI18n, _ } from "../../lang/i18n";
-  setupI18n({ withLocale: getLocaleFromNavigator() });
+  import { init_preferences } from "../../preferences";
+  import { _ } from "../../lang/i18n";
+  
+  init_preferences();
 </script>
 
 <main style="position:absolute" class="uk-position-center uk-margin-large">

--- a/src/lang/i18n.ts
+++ b/src/lang/i18n.ts
@@ -32,8 +32,7 @@ function setupI18n(options) {
   init({
     initialLocale: locale_,
     fallbackLocale: 'en',
-});
-
+  });
 }
 
 

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -1,0 +1,48 @@
+import { invoke } from '@tauri-apps/api/tauri';
+import { writable, get } from 'svelte/store';
+import { getLocaleFromNavigator, setupI18n } from "./lang/i18n";
+
+const empty_preferences = function(): Preferences {
+  return {
+    locale: null
+  }
+}
+
+export const preferences = writable<Preferences>(empty_preferences());
+
+export interface Preferences {
+  locale: string,
+}
+
+export function init_preferences() {
+  console.log(">>> call init_preferences");
+  
+  // avoid using lib without init finished
+  setupI18n({ 
+    withLocale: 'en',
+    fallbackLocale: 'en',
+  });
+
+  invoke('get_preferences')
+    .then((result: Preferences) => {
+      // init locale preference
+      const locale = result.locale 
+        ? result.locale
+        : getLocaleFromNavigator();     
+      setupI18n({ 
+        withLocale: locale,
+        fallbackLocale: 'en',
+      });
+    })
+}
+
+export function setLocale(locale: string) {
+  invoke('set_preferences_locale', { locale: locale })
+    .then(() => {
+      setupI18n({ 
+        withLocale: locale,
+        fallbackLocale: 'en',
+      });
+    })
+}
+


### PR DESCRIPTION
* Displays restored account right away before its balance be fetched from the chain

* Fixes Log card to the bottom

* Adds account events view WIP

* Adds Account Events pagination WIP

* Optimizes events subscription
Fixes events spinner position
Create dummy events table
Clean up code

* Applies language feature to the Events tab - en & pt

* Fixes account off chain display

* Removes dummy events for test

* Adds Portuguese translation

* Fixes Settings components margin

* Changes info icon on the wallet view

* Change app name to Carpe

* Updates Cargo.lock file

* Fixes balance info for different locales than en-US

* Adds persistence to locale preference